### PR TITLE
Add MsQuic OpenSSL package and copy targets to support Windows 10 QUIC

### DIFF
--- a/src/Lithium.Client/Lithium.Client.csproj
+++ b/src/Lithium.Client/Lithium.Client.csproj
@@ -21,4 +21,20 @@
         <ProjectReference Include="..\Lithium.Core\Lithium.Core.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Native.Quic.MsQuic.OpenSSL"
+                          Version="2.3.5"
+                          PrivateAssets="all"
+                          GeneratePathProperty="true" />
+
+        <RuntimeHostConfigurationOption Include="System.Net.Quic.AppLocalMsQuic" Value="true" />
+    </ItemGroup>
+
+    <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
+        <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
+    </Target>
+    <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish">
+        <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />
+    </Target>
+
 </Project>

--- a/src/Lithium.Server/Lithium.Server.csproj
+++ b/src/Lithium.Server/Lithium.Server.csproj
@@ -41,4 +41,20 @@
       <Folder Include="Core\Systems\" />
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Native.Quic.MsQuic.OpenSSL"
+                          Version="2.3.5"
+                          PrivateAssets="all"
+                          GeneratePathProperty="true" />
+
+        <RuntimeHostConfigurationOption Include="System.Net.Quic.AppLocalMsQuic" Value="true" />
+    </ItemGroup>
+
+    <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
+        <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
+    </Target>
+    <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish">
+        <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />
+    </Target>
+
 </Project>


### PR DESCRIPTION
This is a fix related to this issue : https://github.com/dotnet/runtime/pull/103351

Basically, Windows 10 does not support QUIC in .NET, only Windows 11. So we use OpenSSL QUIC instead (slighly bigger size, but unified workflow for everyone).