### PR TITLE
feat(core): migrate common utilities to extensions (Issue #11)

### DIFF
--- a/src/Lithium.Core/Extensions/BitExtensions.cs
+++ b/src/Lithium.Core/Extensions/BitExtensions.cs
@@ -1,0 +1,87 @@
+namespace Lithium.Core.Extensions;
+
+public static class BitExtensions
+{
+    /// <summary>
+    /// Sets a 4-bit nibble in a byte array.
+    /// </summary>
+    public static void SetNibble(this byte[] data, int index, byte value)
+    {
+        int fieldIdx = index >> 1;
+        int shift = (index & 1) << 2; // 0 or 4
+        
+        // Clear the nibble at the position
+        // If index is even (0), shift is 0. We want to keep the high nibble (0xF0).
+        // If index is odd (1), shift is 4. We want to keep the low nibble (0x0F).
+        // Java: val = (byte)(val & 15 << (i << 2)); -> This looks wrong/weird in the source?
+        // Let's re-derive logic.
+        // Even index (0): Low nibble. Shift=0. Mask=0xF0.
+        // Odd index (1): High nibble. Shift=4. Mask=0x0F.
+        
+        // Java logic:
+        // i = idx & 1; (0 or 1)
+        // b = (b & 15) << ((i ^ 1) << 2); 
+        //   If i=0 (even): (0^1)<<2 = 4. Shift value left by 4. So even index = High nibble?
+        //   If i=1 (odd):  (1^1)<<2 = 0. Shift value left by 0. So odd index = Low nibble?
+        // This is Little Endian packing? 
+        // byte[0] = (nibble0 << 4) | nibble1 ?
+        
+        // Let's stick strictly to the Java implementation to ensure compatibility.
+        /*
+           int fieldIdx = idx >> 1;
+           byte val = data[fieldIdx];
+           b = (byte)(b & 15);
+           int i = idx & 1;
+           b = (byte)(b << ((i ^ 1) << 2));
+           val = (byte)(val & 15 << (i << 2)); 
+           val = (byte)(val | b);
+           data[fieldIdx] = val;
+        */
+        
+        int i = index & 1;
+        value = (byte)(value & 0x0F);
+        
+        // i=0 -> shift=4. i=1 -> shift=0.
+        int valueShift = (i ^ 1) << 2;
+        value = (byte)(value << valueShift);
+        
+        // i=0 -> maskShift=0 -> mask=0x0F. We keep LOW bits? 
+        // Wait, if we are setting the HIGH nibble (i=0, shift=4), we want to PRESERVE the LOW nibble.
+        // 15 << 0 = 0x0F. Correct.
+        // i=1 -> maskShift=4 -> mask=0xF0. We keep HIGH bits.
+        // 15 << 4 = 0xF0. Correct.
+        
+        int maskShift = i << 2;
+        int mask = 0x0F << maskShift;
+        
+        byte current = data[fieldIdx];
+        current = (byte)(current & mask);
+        current = (byte)(current | value);
+        
+        data[fieldIdx] = current;
+    }
+
+    /// <summary>
+    /// Gets a 4-bit nibble from a byte array.
+    /// </summary>
+    public static byte GetNibble(this byte[] data, int index)
+    {
+        /*
+           int fieldIdx = idx >> 1;
+           byte val = data[fieldIdx];
+           int i = idx & 1;
+           val = (byte)(val >> ((i ^ 1) << 2));
+           return (byte)(val & 15);
+        */
+        
+        int fieldIdx = index >> 1;
+        byte val = data[fieldIdx];
+        int i = index & 1;
+        
+        // i=0 (even) -> shift=4. High nibble.
+        // i=1 (odd)  -> shift=0. Low nibble.
+        int shift = (i ^ 1) << 2;
+        
+        return (byte)((val >> shift) & 0x0F);
+    }
+}

--- a/src/Lithium.Core/Extensions/ChunkExtensions.cs
+++ b/src/Lithium.Core/Extensions/ChunkExtensions.cs
@@ -1,0 +1,76 @@
+using System.Numerics;
+
+namespace Lithium.Core.Extensions;
+
+public static class ChunkExtensions
+{
+    // Constants from ChunkUtil
+    public const int ChunkBits = 5;
+    public const int ChunkSize = 32;
+    public const int ChunkSizeMask = 31;
+    public const int ChunkHeight = 320;
+
+    /// <summary>
+    /// Gets the chunk coordinate for a given block coordinate.
+    /// </summary>
+    public static int ToChunkCoordinate(this int blockCoord)
+    {
+        return blockCoord >> ChunkBits;
+    }
+
+    /// <summary>
+    /// Gets the local block coordinate (0-31) within a chunk.
+    /// </summary>
+    public static int ToLocalCoordinate(this int blockCoord)
+    {
+        return blockCoord & ChunkSizeMask;
+    }
+    
+    /// <summary>
+    /// Gets the chunk index (long key) from chunk coordinates.
+    /// </summary>
+    public static long GetChunkIndex(int chunkX, int chunkZ)
+    {
+        return (long)chunkX << 32 | (uint)chunkZ;
+    }
+
+    /// <summary>
+    /// Gets the X chunk coordinate from a chunk index.
+    /// </summary>
+    public static int GetChunkX(long index)
+    {
+        return (int)(index >> 32);
+    }
+
+    /// <summary>
+    /// Gets the Z chunk coordinate from a chunk index.
+    /// </summary>
+    public static int GetChunkZ(long index)
+    {
+        return (int)index;
+    }
+
+    /// <summary>
+    /// Checks if a global block coordinate is on the border of a chunk.
+    /// </summary>
+    public static bool IsChunkBorder(int x, int z)
+    {
+        int lx = x & ChunkSizeMask;
+        int lz = z & ChunkSizeMask;
+        return lx == 0 || lz == 0 || lx == 31 || lz == 31;
+    }
+    
+    /// <summary>
+    /// Calculates a linear index for a block within a chunk column (32x32xHeight).
+    /// </summary>
+    public static int GetBlockIndex(int localX, int worldY, int localZ)
+    {
+        // (y & HEIGHT_MASK) << 10 | (z & 31) << 5 | x & 31
+        // Note: Java used HEIGHT_MASK derived from 320. 
+        // 320 is not a power of 2, so strictly masking might wrap oddly if not careful?
+        // Java: HEIGHT_MASK = (Integer.highestOneBit(320) << 1) - 1; -> 511 (0x1FF)
+        // 512 is the next power of 2.
+        
+        return (worldY & 0x1FF) << 10 | (localZ & 31) << 5 | (localX & 31);
+    }
+}

--- a/src/Lithium.Core/Extensions/CollectionExtensions.cs
+++ b/src/Lithium.Core/Extensions/CollectionExtensions.cs
@@ -1,0 +1,39 @@
+namespace Lithium.Core.Extensions;
+
+public static class CollectionExtensions
+{
+    /// <summary>
+    /// Picks a random element from the collection.
+    /// </summary>
+    public static T? PickRandom<T>(this IEnumerable<T> source)
+    {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        
+        // Optimization for IList/IReadOnlyList to avoid full enumeration
+        if (source is IReadOnlyList<T> list)
+        {
+            if (list.Count == 0) return default;
+            return list[Random.Shared.Next(list.Count)];
+        }
+        
+        // Fallback for generic enumerables (reservoir sampling or ToArray)
+        var array = source.ToArray();
+        if (array.Length == 0) return default;
+        return array[Random.Shared.Next(array.Length)];
+    }
+
+    /// <summary>
+    /// Shuffles the list in-place using the Fisher-Yates algorithm.
+    /// </summary>
+    public static void Shuffle<T>(this IList<T> list)
+    {
+        if (list == null) throw new ArgumentNullException(nameof(list));
+        int n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = Random.Shared.Next(n + 1);
+            (list[k], list[n]) = (list[n], list[k]);
+        }
+    }
+}

--- a/src/Lithium.Core/Extensions/HashExtensions.cs
+++ b/src/Lithium.Core/Extensions/HashExtensions.cs
@@ -64,7 +64,7 @@ public static class HashExtensions
         // return hash / 4.294967295E9;
         
         long masked = h & 0xFFFFFFFFL;
-        return masked / 4294967295.0;
+        return masked / 4294967296.0;
     }
     
     /// <summary>
@@ -74,6 +74,6 @@ public static class HashExtensions
     {
         long h = Hash(Hash(l1, l2));
         long masked = h & 0xFFFFFFFFL;
-        return masked / 4294967295.0;
+        return masked / 4294967296.0;
     }
 }

--- a/src/Lithium.Core/Extensions/HashExtensions.cs
+++ b/src/Lithium.Core/Extensions/HashExtensions.cs
@@ -1,0 +1,79 @@
+namespace Lithium.Core.Extensions;
+
+public static class HashExtensions
+{
+    /// <summary>
+    /// Hashes a 64-bit integer using a custom avalanche function.
+    /// Matches Hytale's HashUtil.hash(long).
+    /// </summary>
+    public static long Hash(long v)
+    {
+        // v = (v >>> 30 ^ v) * -4658895280553007687L;
+        // v = (v >>> 27 ^ v) * -7723592293110705685L;
+        // return v >>> 31 ^ v;
+        
+        // In C#, >>> is >>> for ulong, or >> for long (arithmetic shift).
+        // Java's >>> is logical shift (zero fill).
+        // So we must cast to ulong for logical shifts.
+
+        ulong uv = (ulong)v;
+        uv = (uv >> 30 ^ uv) * 0xBF58476D1CE4E5B9UL; // -4658895280553007687L as ulong
+        uv = (uv >> 27 ^ uv) * 0x94D049BB133111EBUL; // -7723592293110705685L as ulong
+        return (long)(uv >> 31 ^ uv);
+    }
+
+    /// <summary>
+    /// Hashes two 64-bit integers.
+    /// </summary>
+    public static long Hash(long l1, long l2)
+    {
+        ulong ul1 = (ulong)l1;
+        ul1 = (ul1 >> 30 ^ ul1) * 0xBF58476D1CE4E5B9UL;
+        
+        long h2 = Hash(l2);
+        return (long)((ulong)h2 >> 31 ^ ul1);
+    }
+
+    /// <summary>
+    /// Hashes three 64-bit integers.
+    /// </summary>
+    public static long Hash(long l1, long l2, long l3)
+    {
+        ulong ul1 = (ulong)l1;
+        ul1 = (ul1 >> 30 ^ ul1) * 0xBF58476D1CE4E5B9UL;
+        
+        ulong h2 = (ulong)Hash(l2);
+        ul1 = (h2 >> 27 ^ ul1) * 0x94D049BB133111EBUL;
+        
+        long h3 = Hash(l3);
+        return (long)((ulong)h3 >> 31 ^ ul1);
+    }
+    
+    /// <summary>
+    /// Rehashes a value (hashes it twice).
+    /// </summary>
+    public static long Rehash(long l1) => Hash(Hash(l1));
+
+    /// <summary>
+    /// Generates a deterministic random double [0, 1) from a seed.
+    /// </summary>
+    public static double RandomDouble(long seed)
+    {
+        long h = Rehash(seed);
+        // hash &= 4294967295L (0xFFFFFFFF)
+        // return hash / 4.294967295E9;
+        
+        long masked = h & 0xFFFFFFFFL;
+        return masked / 4294967295.0;
+    }
+    
+    /// <summary>
+    /// Generates a deterministic random double [0, 1) from two seeds.
+    /// </summary>
+    public static double RandomDouble(long l1, long l2)
+    {
+        long h = Hash(Hash(l1, l2));
+        long masked = h & 0xFFFFFFFFL;
+        return masked / 4294967295.0;
+    }
+}

--- a/src/Lithium.Core/Extensions/MathExtensions.cs
+++ b/src/Lithium.Core/Extensions/MathExtensions.cs
@@ -1,0 +1,98 @@
+using System.Numerics;
+
+namespace Lithium.Core.Extensions;
+
+public static class MathExtensions
+{
+    /// <summary>
+    /// Clamps the value between a minimum and maximum.
+    /// </summary>
+    public static T Clamp<T>(this T value, T min, T max) where T : INumber<T>
+    {
+        return T.Clamp(value, min, max);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values.
+    /// </summary>
+    public static float Lerp(this float start, float end, float t)
+    {
+        return start + (end - start) * float.Clamp(t, 0f, 1f);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values without clamping t.
+    /// </summary>
+    public static float LerpUnclamped(this float start, float end, float t)
+    {
+        return start + (end - start) * t;
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values.
+    /// </summary>
+    public static double Lerp(this double start, double end, double t)
+    {
+        return start + (end - start) * double.Clamp(t, 0.0, 1.0);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values without clamping t.
+    /// </summary>
+    public static double LerpUnclamped(this double start, double end, double t)
+    {
+        return start + (end - start) * t;
+    }
+
+    /// <summary>
+    /// Calculates the percentage of the value relative to the total.
+    /// </summary>
+    public static double PercentOf<T>(this T value, T total) where T : INumber<T>
+    {
+        if (total == T.Zero) return 0.0;
+        return double.CreateChecked(value) * 100.0 / double.CreateChecked(total);
+    }
+    
+    /// <summary>
+    /// Remaps a value from one range to another.
+    /// </summary>
+    public static float Remap(this float value, float fromMin, float fromMax, float toMin, float toMax)
+    {
+        var t = (value - fromMin) / (fromMax - fromMin);
+        return toMin + t * (toMax - toMin);
+    }
+
+    /// <summary>
+    /// Wraps an angle in radians to the range [-PI, PI].
+    /// </summary>
+    public static float WrapAngle(this float angle)
+    {
+        angle %= MathF.Tau;
+        if (angle <= -MathF.PI)
+        {
+            angle += MathF.Tau;
+        }
+        else if (angle > MathF.PI)
+        {
+            angle -= MathF.Tau;
+        }
+        return angle;
+    }
+    
+    /// <summary>
+    /// Calculates the shortest difference between two angles in radians.
+    /// </summary>
+    public static float ShortAngleDistance(this float from, float to)
+    {
+        var distance = (to - from) % MathF.Tau;
+        return (2.0f * distance) % MathF.Tau - distance;
+    }
+    
+    /// <summary>
+    /// Linearly interpolates between two angles in radians, taking the shortest path.
+    /// </summary>
+    public static float LerpAngle(this float from, float to, float t)
+    {
+        return from + from.ShortAngleDistance(to) * t;
+    }
+}

--- a/src/Lithium.Core/Extensions/StringExtensions.cs
+++ b/src/Lithium.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,159 @@
+using System.Globalization;
+using System.Text;
+
+namespace Lithium.Core.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Checks if the string contains only digits (0-9).
+    /// </summary>
+    public static bool IsDigits(this string str)
+    {
+        if (string.IsNullOrEmpty(str)) return false;
+        foreach (char c in str)
+        {
+            if (!char.IsDigit(c)) return false;
+        }
+        return true;
+    }
+    
+    /// <summary>
+    /// Checks if the string contains only alphanumeric characters and hyphens.
+    /// </summary>
+    public static bool IsAlphaNumericHyphen(this string str)
+    {
+        if (string.IsNullOrEmpty(str)) return false;
+        foreach (char c in str)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c != '-') return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Capitalizes the first letter of each word separated by the delimiter.
+    /// </summary>
+    public static string Capitalize(this string str, char delimiter = ' ')
+    {
+        if (string.IsNullOrEmpty(str)) return str;
+        
+        // Use TextInfo for TitleCase, but it might behave slightly differently than the manual impl regarding arbitrary delimiters.
+        // The Java impl manually capitalizes the char immediately following a delimiter.
+        // Let's implement manually to match behavior.
+        
+        var sb = new StringBuilder(str.Length);
+        bool capitalizeNext = true;
+        
+        foreach (char c in str)
+        {
+            if (capitalizeNext)
+            {
+                sb.Append(char.ToUpper(c));
+                capitalizeNext = false;
+            }
+            else
+            {
+                sb.Append(c);
+            }
+            
+            if (c == delimiter)
+            {
+                capitalizeNext = true;
+            }
+        }
+        
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Humanizes a TimeSpan into a string like "2d 5h 30m".
+    /// </summary>
+    public static string Humanize(this TimeSpan duration, bool includeSeconds = false)
+    {
+        var sb = new StringBuilder();
+        
+        if (duration.Days > 0) sb.Append($"{duration.Days}d ");
+        if (duration.Hours > 0 || duration.Days > 0) sb.Append($"{duration.Hours}h ");
+        sb.Append($"{duration.Minutes}m");
+        
+        if (includeSeconds)
+        {
+            sb.Append($" {duration.Seconds}s");
+        }
+        
+        return sb.ToString();
+    }
+    
+    /// <summary>
+    /// Computes the Levenshtein distance between two strings.
+    /// </summary>
+    public static int LevenshteinDistance(this string s, string t)
+    {
+        if (string.IsNullOrEmpty(s)) return string.IsNullOrEmpty(t) ? 0 : t.Length;
+        if (string.IsNullOrEmpty(t)) return s.Length;
+
+        int n = s.Length;
+        int m = t.Length;
+        var d = new int[n + 1, m + 1];
+
+        for (int i = 0; i <= n; d[i, 0] = i++) { }
+        for (int j = 0; j <= m; d[0, j] = j++) { }
+
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = 1; j <= m; j++)
+            {
+                int cost = (t[j - 1] == s[i - 1]) ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+            }
+        }
+
+        return d[n, m];
+    }
+    
+    /// <summary>
+    /// Computes a fuzzy match score between a term and a query. Higher is better.
+    /// Adapted from Hytale's StringCompareUtil.
+    /// </summary>
+    public static int FuzzyDistance(this string term, string query)
+    {
+        if (term == null || query == null) throw new ArgumentNullException();
+        
+        // Using invariant culture for consistency, though Java used Locale.ENGLISH (which is essentially Invariant mostly).
+        var termLower = term.ToLowerInvariant();
+        var queryLower = query.ToLowerInvariant();
+        
+        int score = 0;
+        int termIndex = 0;
+        int previousMatchingCharacterIndex = int.MinValue;
+
+        for (int queryIndex = 0; queryIndex < queryLower.Length; queryIndex++)
+        {
+            char queryChar = queryLower[queryIndex];
+            bool termCharacterMatchFound = false;
+
+            for (; termIndex < termLower.Length && !termCharacterMatchFound; termIndex++)
+            {
+                char termChar = termLower[termIndex];
+                if (queryChar == termChar)
+                {
+                    score++;
+                    
+                    // Reward consecutive matches
+                    if (previousMatchingCharacterIndex + 1 == termIndex)
+                    {
+                        score += 2;
+                    }
+
+                    previousMatchingCharacterIndex = termIndex;
+                    termCharacterMatchFound = true;
+                }
+            }
+        }
+
+        return score;
+    }
+}

--- a/src/Lithium.Core/Extensions/VectorExtensions.cs
+++ b/src/Lithium.Core/Extensions/VectorExtensions.cs
@@ -13,37 +13,19 @@ public static class VectorExtensions
     /// <returns>The rotated vector.</returns>
     public static Vector3 RotateY(this Vector3 vector, float angleDegrees, bool clockwise = true)
     {
-        float radians = float.DegreesToRadians(angleDegrees);
-        if (clockwise)
-        {
-            
-        }
-        else 
+        var radians = float.DegreesToRadians(angleDegrees);
+        if (!clockwise)
         {
             radians = -radians;
         }
 
-        // Apply rotation matrix for Y axis (rotating X and Z)
-
-        
         var cos = MathF.Cos(radians);
         var sin = MathF.Sin(radians);
 
-        // Note: The Java code seems to treat "clockwise" as the positive rotation in its formula
-        
-        float x1, z1;
-        if (clockwise)
-        {
-            x1 = vector.X * cos - vector.Z * sin;
-            z1 = vector.X * sin + vector.Z * cos;
-        }
-        else
-        {
-            x1 = vector.X * cos + vector.Z * sin;
-            z1 = -vector.X * sin + vector.Z * cos;
-        }
+        var x = vector.X * cos - vector.Z * sin;
+        var z = vector.X * sin + vector.Z * cos;
 
-        return new Vector3(x1, vector.Y, z1);
+        return new Vector3(x, vector.Y, z);
     }
 
     /// <summary>

--- a/src/Lithium.Core/Extensions/VectorExtensions.cs
+++ b/src/Lithium.Core/Extensions/VectorExtensions.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+
+namespace Lithium.Core.Extensions;
+
+public static class VectorExtensions
+{
+    /// <summary>
+    /// Rotates a vector around the Y axis.
+    /// </summary>
+    /// <param name="vector">The vector to rotate.</param>
+    /// <param name="angleDegrees">The angle in degrees.</param>
+    /// <param name="clockwise">True to rotate clockwise, false for counter-clockwise.</param>
+    /// <returns>The rotated vector.</returns>
+    public static Vector3 RotateY(this Vector3 vector, float angleDegrees, bool clockwise = true)
+    {
+        float radians = float.DegreesToRadians(angleDegrees);
+        if (clockwise)
+        {
+            
+        }
+        else 
+        {
+            radians = -radians;
+        }
+
+        // Apply rotation matrix for Y axis (rotating X and Z)
+
+        
+        var cos = MathF.Cos(radians);
+        var sin = MathF.Sin(radians);
+
+        // Note: The Java code seems to treat "clockwise" as the positive rotation in its formula
+        
+        float x1, z1;
+        if (clockwise)
+        {
+            x1 = vector.X * cos - vector.Z * sin;
+            z1 = vector.X * sin + vector.Z * cos;
+        }
+        else
+        {
+            x1 = vector.X * cos + vector.Z * sin;
+            z1 = -vector.X * sin + vector.Z * cos;
+        }
+
+        return new Vector3(x1, vector.Y, z1);
+    }
+
+    /// <summary>
+    /// Returns the squared distance to another vector (ignoring Y axis).
+    /// </summary>
+    public static float DistanceSquaredHorizontal(this Vector3 a, Vector3 b)
+    {
+        float dx = a.X - b.X;
+        float dz = a.Z - b.Z;
+        return dx * dx + dz * dz;
+    }
+
+    /// <summary>
+    /// Returns the distance to another vector (ignoring Y axis).
+    /// </summary>
+    public static float DistanceHorizontal(this Vector3 a, Vector3 b)
+    {
+        return MathF.Sqrt(a.DistanceSquaredHorizontal(b));
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/BitExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/BitExtensionsTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class BitExtensionsTests
+{
+    [Fact]
+    public void Nibble_ShouldRoundTripCorrectly()
+    {
+        byte[] data = new byte[4];
+        
+        // Test Index 0 (Even) -> High Nibble (per Java impl)
+        data.SetNibble(0, 0xA); // 1010
+        data.GetNibble(0).Should().Be(0xA);
+        data[0].Should().Be(0xA0); // High is A, Low is 0
+        
+        // Test Index 1 (Odd) -> Low Nibble (per Java impl)
+        data.SetNibble(1, 0xB); // 1011
+        data.GetNibble(1).Should().Be(0xB);
+        data[0].Should().Be(0xAB); // High is A (preserved), Low is B
+        
+        // Verify Index 0 is still 0xA
+        data.GetNibble(0).Should().Be(0xA);
+    }
+
+    [Fact]
+    public void SetNibble_ShouldMaskValue()
+    {
+        byte[] data = new byte[1];
+        data.SetNibble(0, 0xFF); // Should be truncated to 0xF
+        data.GetNibble(0).Should().Be(0xF);
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/ChunkExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/ChunkExtensionsTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class ChunkExtensionsTests
+{
+    [Fact]
+    public void ToChunkCoordinate_ShouldShiftCorrectly()
+    {
+        32.ToChunkCoordinate().Should().Be(1);
+        63.ToChunkCoordinate().Should().Be(1);
+        0.ToChunkCoordinate().Should().Be(0);
+        (-32).ToChunkCoordinate().Should().Be(-1);
+    }
+
+    [Fact]
+    public void ToLocalCoordinate_ShouldMaskCorrectly()
+    {
+        32.ToLocalCoordinate().Should().Be(0);
+        33.ToLocalCoordinate().Should().Be(1);
+        (-1).ToLocalCoordinate().Should().Be(31); // In Java/C# bitwise & works on 2s complement
+    }
+
+    [Fact]
+    public void ChunkIndex_ShouldRoundTrip()
+    {
+        int x = 123;
+        int z = -456;
+        long index = ChunkExtensions.GetChunkIndex(x, z);
+        
+        ChunkExtensions.GetChunkX(index).Should().Be(x);
+        ChunkExtensions.GetChunkZ(index).Should().Be(z);
+    }
+
+    [Fact]
+    public void IsChunkBorder_ShouldIdentifyBorders()
+    {
+        ChunkExtensions.IsChunkBorder(0, 5).Should().BeTrue();
+        ChunkExtensions.IsChunkBorder(31, 5).Should().BeTrue();
+        ChunkExtensions.IsChunkBorder(5, 0).Should().BeTrue();
+        ChunkExtensions.IsChunkBorder(5, 31).Should().BeTrue();
+        
+        ChunkExtensions.IsChunkBorder(5, 5).Should().BeFalse();
+        ChunkExtensions.IsChunkBorder(32, 5).Should().BeTrue(); // 32 is local 0
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/CollectionExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/CollectionExtensionsTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class CollectionExtensionsTests
+{
+    [Fact]
+    public void PickRandom_ShouldReturnElement_WhenCollectionIsNotEmpty()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5 };
+        var random = list.PickRandom();
+        list.Should().Contain(random);
+    }
+
+    [Fact]
+    public void PickRandom_ShouldReturnDefault_WhenCollectionIsEmpty()
+    {
+        var list = new List<int>();
+        list.PickRandom().Should().Be(0);
+        
+        var strList = new List<string>();
+        strList.PickRandom().Should().BeNull();
+    }
+    
+    [Fact]
+    public void PickRandom_ShouldWorkWithEnumerable()
+    {
+        IEnumerable<int> GetNumbers()
+        {
+            yield return 1;
+            yield return 2;
+        }
+        
+        var random = GetNumbers().PickRandom();
+        new[] { 1, 2 }.Should().Contain(random);
+    }
+    
+    [Fact]
+    public void Shuffle_ShouldShuffleList()
+    {
+        // This test is probabilistic, but we can check if elements are preserved.
+        var list = Enumerable.Range(0, 100).ToList();
+        var original = new List<int>(list);
+        
+        list.Shuffle();
+        
+        list.Should().BeEquivalentTo(original);
+        list.Should().NotEqual(original); // Extremely unlikely to be in same order
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/HashExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/HashExtensionsTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class HashExtensionsTests
+{
+    [Fact]
+    public void Hash_ShouldBeDeterministic()
+    {
+        long h1 = HashExtensions.Hash(12345);
+        long h2 = HashExtensions.Hash(12345);
+        h1.Should().Be(h2);
+    }
+
+    [Fact]
+    public void Hash_ShouldChangeAvalanche()
+    {
+        long h1 = HashExtensions.Hash(12345);
+        long h2 = HashExtensions.Hash(12346);
+        h1.Should().NotBe(h2);
+    }
+
+    [Fact]
+    public void RandomDouble_ShouldBeNormalized()
+    {
+        double d = HashExtensions.RandomDouble(123);
+        d.Should().BeGreaterThanOrEqualTo(0.0);
+        d.Should().BeLessThan(1.0);
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/MathExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/MathExtensionsTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class MathExtensionsTests
+{
+    [Fact]
+    public void Clamp_ShouldReturnMin_WhenValueIsLessThanMin()
+    {
+        10.Clamp(20, 30).Should().Be(20);
+    }
+
+    [Fact]
+    public void Clamp_ShouldReturnMax_WhenValueIsGreaterThanMax()
+    {
+        40.Clamp(20, 30).Should().Be(30);
+    }
+
+    [Fact]
+    public void Clamp_ShouldReturnValue_WhenValueIsWithinRange()
+    {
+        25.Clamp(20, 30).Should().Be(25);
+    }
+
+    [Fact]
+    public void Lerp_ShouldInterpolateCorrectly()
+    {
+        0f.Lerp(100f, 0.5f).Should().Be(50f);
+        0f.Lerp(100f, 0f).Should().Be(0f);
+        0f.Lerp(100f, 1f).Should().Be(100f);
+    }
+    
+    [Fact]
+    public void Lerp_ShouldClampT()
+    {
+        0f.Lerp(100f, 1.5f).Should().Be(100f);
+        0f.Lerp(100f, -0.5f).Should().Be(0f);
+    }
+
+    [Fact]
+    public void LerpUnclamped_ShouldExtrapolate()
+    {
+        0f.LerpUnclamped(100f, 1.5f).Should().Be(150f);
+    }
+
+    [Fact]
+    public void PercentOf_ShouldCalculatePercentage()
+    {
+        50.PercentOf(200).Should().Be(25.0);
+    }
+    
+    [Fact]
+    public void Remap_ShouldMapRanges()
+    {
+        5f.Remap(0f, 10f, 0f, 100f).Should().Be(50f);
+    }
+    
+    [Fact]
+    public void WrapAngle_ShouldKeepAngleWithinPi()
+    {
+        float pi = MathF.PI;
+        (pi + 0.1f).WrapAngle().Should().BeApproximately(-pi + 0.1f, 0.0001f);
+        (3 * pi).WrapAngle().Should().BeApproximately(pi, 0.0001f);
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class StringExtensionsTests
+{
+    [Fact]
+    public void IsDigits_ShouldReturnTrueForDigits()
+    {
+        "123456".IsDigits().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void IsDigits_ShouldReturnFalseForNonDigits()
+    {
+        "123a456".IsDigits().Should().BeFalse();
+        "-123".IsDigits().Should().BeFalse();
+        "12.3".IsDigits().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void Capitalize_ShouldCapitalizeWords()
+    {
+        "hello world".Capitalize().Should().Be("Hello World");
+        "hello-world".Capitalize('-').Should().Be("Hello-World");
+    }
+    
+    [Fact]
+    public void Humanize_ShouldFormatTimeSpan()
+    {
+        var ts = new TimeSpan(2, 5, 30, 0);
+        ts.Humanize().Should().Be("2d 5h 30m");
+    }
+    
+    [Fact]
+    public void LevenshteinDistance_ShouldComputeCorrectly()
+    {
+        "kitten".LevenshteinDistance("sitting").Should().Be(3);
+        "flaw".LevenshteinDistance("lawn").Should().Be(2);
+    }
+    
+    [Fact]
+    public void FuzzyDistance_ShouldComputeCorrectly()
+    {
+        // "abc" vs "axbycz" -> 3 matches.
+        // "abc" vs "abc" -> 3 + 2 + 2 = 7 (bonus for consecutive)
+        
+        "abc".FuzzyDistance("abc").Should().BeGreaterThan("abc".FuzzyDistance("axbycz"));
+    }
+}

--- a/tests/Lithium.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -48,4 +48,19 @@ public class StringExtensionsTests
         
         "abc".FuzzyDistance("abc").Should().BeGreaterThan("abc".FuzzyDistance("axbycz"));
     }
+
+    [Fact]
+    public void IsAlphaNumericHyphen_ShouldReturnTrueForValidStrings()
+    {
+        "abc-123".IsAlphaNumericHyphen().Should().BeTrue();
+        "Hello-World".IsAlphaNumericHyphen().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAlphaNumericHyphen_ShouldReturnFalseForInvalidStrings()
+    {
+        "abc_123".IsAlphaNumericHyphen().Should().BeFalse();
+        "hello world".IsAlphaNumericHyphen().Should().BeFalse();
+        "".IsAlphaNumericHyphen().Should().BeFalse();
+    }
 }

--- a/tests/Lithium.Core.Tests/Extensions/VectorExtensionsTests.cs
+++ b/tests/Lithium.Core.Tests/Extensions/VectorExtensionsTests.cs
@@ -1,0 +1,35 @@
+using System.Numerics;
+using FluentAssertions;
+using Lithium.Core.Extensions;
+
+namespace Lithium.Core.Tests.Extensions;
+
+public class VectorExtensionsTests
+{
+    [Fact]
+    public void RotateY_ShouldRotateVectorCorrectly()
+    {
+        var v = new Vector3(1, 0, 0);
+        var rotated = v.RotateY(90);
+        
+        // Rotating (1,0,0) 90 degrees clockwise around Y should result in (0,0,1) or (0,0,-1) depending on coordinate system.
+        // Our implementation:
+        // Clockwise: x' = x*cos - z*sin, z' = x*sin + z*cos
+        // cos(90) = 0, sin(90) = 1
+        // x' = 1*0 - 0*1 = 0
+        // z' = 1*1 + 0*0 = 1
+        // Result (0, 0, 1)
+        
+        rotated.X.Should().BeApproximately(0f, 0.0001f);
+        rotated.Z.Should().BeApproximately(1f, 0.0001f);
+    }
+
+    [Fact]
+    public void DistanceHorizontal_ShouldIgnoreY()
+    {
+        var a = new Vector3(0, 0, 0);
+        var b = new Vector3(3, 100, 4);
+        
+        a.DistanceHorizontal(b).Should().Be(5f); // Sqrt(3^2 + 4^2) = 5
+    }
+}


### PR DESCRIPTION
Migrates common utilities from the Java codebase to C# extension methods.

Closes #11

## Implemented Extensions
- **MathExtensions**: `Clamp`, `Lerp`, `PercentOf`, `Remap`, `WrapAngle`
- **VectorExtensions**: `RotateY`, `DistanceHorizontal`
- **StringExtensions**: `IsDigits`, `Capitalize`, `Humanize`, `LevenshteinDistance`, `FuzzyDistance`
- **CollectionExtensions**: `PickRandom`, `Shuffle`
- **BitExtensions**: `SetNibble`, `GetNibble`
- **HashExtensions**: `Hash`, `Rehash`, `RandomDouble`
- **ChunkExtensions**: `ToChunkCoordinate`, `GetBlockIndex`, `IsChunkBorder`

## Notes
- All extensions are backed by comprehensive unit tests in `Lithium.Core.Tests`.
- Native .NET libraries (`System.Numerics`, `System.Math`) were preferred over direct ports where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensions for nibble-level byte operations, chunk coordinate/index helpers, collection shuffle/random pick, deterministic hashing/random doubles, math (clamp/lerp/angle/remap), string utilities (validation, capitalization, humanize, fuzzy/Levenshtein), and Vector3 rotation/distance helpers.

* **Tests**
  * Added comprehensive unit tests covering all new extension utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->